### PR TITLE
Added `rng` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install random-jpeg --save
 ```
 
 
-## example
+## examples
 
 ```javascript
 var randomJpeg = require('random-jpeg');
@@ -32,6 +32,21 @@ randomJpeg.writeJPEG(destination, imageOptions, callback);
 
 // without any options or callback
 randomJpeg.writeJPEG(destination);
+```
+
+
+### example with custom rng
+```javascript
+var randomJpeg = require('random-jpeg');
+var faker = require('faker');
+faker.seed( 4 ); // chosen by fair dice roll. guaranteed to be random :)
+
+// with options and callback
+var imageOptions = {
+  rng: faker.random.number.bind( faker.random, { min: 0, max: 1, precision: .00001 } )
+};
+// will always produce the same "random" jpeg on every invocation now, useful for deterministic tests
+randomJpeg.writeJPEG(destination, imageOptions, callback);
 ```
 
 
@@ -56,6 +71,9 @@ The length of the colorArray has to be (XPosArray.length - 1 * YPosArray.length 
 * columns: number of rectangles in x-direction  
 * rows: number of rectangles in x-direction  
 * allowSameColorTouch: are rectangles with the same color connected allowed  
-* quality:  jpeg encoding quality
+* quality: jpeg encoding quality
+* rng: A custom random number generator. Should be a function
+  returning a number in the range of [0, 1) just like
+  `Math.random`. Will default to `Math.random` if not specified.
 
 ![example1](doc/example2.jpg )

--- a/index.js
+++ b/index.js
@@ -19,20 +19,21 @@ function compareNumbers(a, b) {
     return a - b;
 }
 
-function generateDimArray( dimlenght, nrOfTilesInDim ) {
+function generateDimArray( dimlenght, nrOfTilesInDim, rng ) {
     var result = [0];
     result.push( dimlenght);
     for( var i = 0; i < nrOfTilesInDim -1; i++) {
-        result.push( Math.floor( Math.random() * dimlenght ) );
+        result.push( Math.floor( rng() * dimlenght ) );
     }
     return result.sort(compareNumbers);
 }
 
 
-function generateExtendedColorArray( imageOptions){
+function generateExtendedColorArray( imageOptions ){
     var extColors = [];
     var nrOfTiles = imageOptions.columns * imageOptions.rows;
     var index;
+    var rng = imageOptions.rng || Math.random;
 
     if( imageOptions.colors === undefined){
         var nrOfDefaultColors = 6;
@@ -42,14 +43,14 @@ function generateExtendedColorArray( imageOptions){
         // TODO same color could be chosen several times --> without imageOptions.colors
         // TODO allowSameColorTouch doesn't work correctly
         for( var j = 0; j < nrOfDefaultColors; j++){
-            index = Math.floor( Math.random() * colorArray.length );
+            index = Math.floor( rng() * colorArray.length );
             imageOptions.colors[j] = colorArray[index];
         }
     }
 
     if( imageOptions.allowSameColorTouch ) {
         for( var i = 0; i < nrOfTiles; i++ ) {
-            index = Math.floor( Math.random() * imageOptions.colors.length );
+            index = Math.floor( rng() * imageOptions.colors.length );
             extColors.push( imageOptions.colors[index]);
         }
     }else{
@@ -58,7 +59,7 @@ function generateExtendedColorArray( imageOptions){
         var indicesTilesRowAbove = new Array(imageOptions.columns);
         while( extColors.length < nrOfTiles ){
             columnPos = extColors.length % imageOptions.columns;
-            index = Math.floor( Math.random() * imageOptions.colors.length );
+            index = Math.floor( rng() * imageOptions.colors.length );
             if( index != indexTileLeft && index != indicesTilesRowAbove[columnPos]) {
                 indexTileLeft = index;
                 indicesTilesRowAbove[columnPos] = index;
@@ -123,9 +124,9 @@ randomJPEG.drawJPEG = function( imageOptions ) {
     if( imageOptions.rows === undefined ){
         imageOptions.rows = 4;
     }
-    var extColors = generateExtendedColorArray( imageOptions);
-    var xs = generateDimArray(imageOptions.width, imageOptions.columns);
-    var ys = generateDimArray(imageOptions.height, imageOptions.rows);
+    var extColors = generateExtendedColorArray( imageOptions );
+    var xs = generateDimArray(imageOptions.width, imageOptions.columns, imageOptions.rng || Math.random);
+    var ys = generateDimArray(imageOptions.height, imageOptions.rows, imageOptions.rng || Math.random);
 
     var buffer = randomJPEG.createBuffer( extColors, xs, ys);
     return randomJPEG.encodeImage( buffer, imageOptions);


### PR DESCRIPTION
I needed a way to generate random images for my unit tests but wanted the images to be the same across test runs, so I added this little feature:

```
Allows supplying an additional `rng` option to all methods which will
be used instead of `Math.random` to generate the random image. Useful
for when deterministic "random" images are wanted (e.g. during tests).
```

Hope you don't mind - would be glad to see this published :)